### PR TITLE
Issue 47 add local signup with passport, #47

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const routes = require('./src/server/routes');
 const bodyParser = require('body-parser');
 const morgan     = require('morgan');
 
+const configuredPassport = require('./config/passport');
 const app = express();
 
 if (config.env === 'development') {
@@ -19,6 +20,10 @@ if (config.env === 'development') {
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+
+// Set up passport
+app.use(configuredPassport.initialize());
+app.use(configuredPassport.session());
 
 routes(app);
 

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const express = require('express');
 const config = require('./config');
 const PORT   = config.port;
 const db     = require('./src/models');
+const routes = require('./src/server/routes');
 
 const bodyParser = require('body-parser');
 const morgan     = require('morgan');
@@ -19,7 +20,7 @@ if (config.env === 'development') {
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
-require('./src/server/routes')(app);
+routes(app);
 
 if (config.env === 'development') {
   // Run server and log database info

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,0 +1,11 @@
+const passport      = require("passport");
+
+passport.serializeUser(function(user, cb) {
+  cb(null, user);
+});
+
+passport.deserializeUser(function(obj, cb) {
+  cb(null, obj);
+});
+
+module.exports = passport;

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,4 +1,6 @@
 const passport      = require("passport");
+const LocalStrategy = require('passport-local').Strategy;
+const db            = require('../src/models/');
 
 passport.serializeUser(function(user, cb) {
   cb(null, user);
@@ -7,5 +9,45 @@ passport.serializeUser(function(user, cb) {
 passport.deserializeUser(function(obj, cb) {
   cb(null, obj);
 });
+
+passport.use('local-signup', new LocalStrategy(
+  {
+    // Field names must match request body
+    usernameField : 'email',
+    passwordField : 'password',
+  },
+  function(email, password, done) {
+    db.User.findOne({
+      where: {
+        email: email
+      }
+    }).then(function(dbUser) {
+      // If there's an existing user with the same email
+      if (dbUser) {
+        return done(null, false, {
+          message: "Email is already taken.",
+        });
+      }
+
+      // If there email is available, try to create a new user
+      else {
+        db.User.create({
+          email: email,
+          name: email,
+          username: email,
+          passwordHash: password,
+        }).then(function(newUser) {
+          // Successfully created a new user
+          return done(null, newUser);
+        }).catch(function(err) {
+          // Failed to create a new user.
+          return done(null, false, {
+              message: "Error creating new account.",
+            });
+        });
+      }
+    });
+  }
+));
 
 module.exports = passport;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "passport-local": "1.0.0",
     "pug": "2.0.3",
     "sequelize": "4.38.0",
+    "sinon": "7.0.0",
     "yarn": "1.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express": "4.16.3",
     "morgan": "1.9.1",
     "mysql2": "1.6.1",
+    "passport": "0.4.0",
     "pug": "2.0.3",
     "sequelize": "4.38.0",
     "yarn": "1.7.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "morgan": "1.9.1",
     "mysql2": "1.6.1",
     "passport": "0.4.0",
+    "passport-local": "1.0.0",
     "pug": "2.0.3",
     "sequelize": "4.38.0",
     "yarn": "1.7.0"

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -35,6 +35,11 @@ module.exports = (app) => {
   });
 
   // Sign up form
+  app.get('/signup', function(req, res) {
+    res.render('signup', {
+      title: 'JP Signup',
+    });
+  });
 
   // --- Handle data --- //
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -14,7 +14,7 @@ module.exports = (app) => {
   app.get('/api/users', usersController.list);
   app.get('/api/users/:username', usersController.retrieve);
 
-  app.get('/app', function (req, res) {
+  app.get('/', function (req, res) {
     res.statusCode = 200;
     res.setHeader('Content-Type', 'text/html');
     res.render('index', {

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const usersController = require('../controllers').users;
+const configuredPassport = require('../../../config/passport');
 
 module.exports = (app) => {
   app.set('views', './src/views');
@@ -44,6 +45,13 @@ module.exports = (app) => {
   // --- Handle data --- //
 
   // Receive Signup Submission
+  app.post('/signup', configuredPassport.authenticate(
+    'local-signup',
+    {
+      successRedirect: '/profile',
+      failureRedirect: '/signup',
+    })
+  );
 
   // ------- END AUTHENTICATION ROUTES ------- //
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -28,6 +28,11 @@ module.exports = (app) => {
   // --- Views --- //
 
   // Profile view (authenticated users only)
+  app.get('/profile', function(req, res) {
+    res.render('profile', {
+      title: 'JP Profile',
+    });
+  });
 
   // Sign up form
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -23,6 +23,20 @@ module.exports = (app) => {
     });
   });
 
+  // ------- AUTHENTICATION ROUTES ------- //
+
+  // --- Views --- //
+
+  // Profile view (authenticated users only)
+
+  // Sign up form
+
+  // --- Handle data --- //
+
+  // Receive Signup Submission
+
+  // ------- END AUTHENTICATION ROUTES ------- //
+
   // Catch-all route must be last
   app.get('*', function (req, res) {
     res.statusCode = 404;

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -2,4 +2,7 @@ html
   head
     title= title
   body
-    h1= message
+    div
+      h1= message
+    hr
+    a(href='/signup') Local Sign Up

--- a/src/views/profile.pug
+++ b/src/views/profile.pug
@@ -1,0 +1,7 @@
+html
+  head
+    title= title
+  body
+    | Profile page
+    hr
+    a(href='/') Home

--- a/src/views/signup.pug
+++ b/src/views/signup.pug
@@ -1,0 +1,15 @@
+html
+  head
+    title= title
+  body
+    div
+      form(action='/signup', method='post')
+        .form-group
+          label Email
+          input.form-control(type='text', name='email')
+        .form-group
+          label Password
+          input.form-control(type='password', name='password')
+        button(type='submit') Signup
+      hr
+      a(href='/') Home

--- a/test/app.js
+++ b/test/app.js
@@ -12,6 +12,17 @@ describe('GET /', () => {
   });
 });
 
+describe('Authentication', () => {
+  describe('Signup', () => {
+    it('should GET /signup', (done) => {
+      request(app)
+        .get('/signup')
+        .expect(200)
+        .end(done);
+    });
+  });
+});
+
 describe('Account', () => {
   describe('Profile', () => {
     it('should GET /profile', (done) => {

--- a/test/app.js
+++ b/test/app.js
@@ -77,6 +77,25 @@ describe('Authentication', () => {
           done();
         });
     });
+
+    it('should redirect to /signup on failed POST /signup when user creation fails', (done) => {
+      findOneStub.resolves(false);
+      createStub.resolves(null);
+
+      const data = {
+        email: 'jose@email.com',
+        password: 'secretpassword',
+      };
+
+      request(app)
+        .post('/signup')
+        .send(data)
+        .expect(302)
+        .end((err, res) => {
+          expect(res.header.location).to.include('/signup');
+          done();
+        });
+    });
   });
 });
 

--- a/test/app.js
+++ b/test/app.js
@@ -3,10 +3,10 @@
 const request = require('supertest');
 const app = require('../app');
 
-describe('GET /app', () => {
+describe('GET /', () => {
   it('should return 200 OK', (done) => {
     request(app)
-      .get('/app')
+      .get('/')
       .expect(200)
       .end(done);
   });
@@ -24,10 +24,10 @@ describe('GET /api', () => {
   });
 });
 
-describe('GET /', () => {
+describe('404 Not Found', () => {
   it('should return 404 Not Found', (done) => {
     request(app)
-      .get('/')
+      .get('/doesntexist')
       .expect(404)
       .end(done);
   });

--- a/test/app.js
+++ b/test/app.js
@@ -1,7 +1,15 @@
 'use strict';
 
 const request = require('supertest');
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
 const app = require('../app');
+const User = require('../src/models').User;
 
 describe('GET /', () => {
   it('should return 200 OK', (done) => {
@@ -13,12 +21,43 @@ describe('GET /', () => {
 });
 
 describe('Authentication', () => {
+  let createStub;
+  let findOneStub;
+
+  beforeEach(function() {
+    createStub = sandbox.stub(User, 'create');
+    findOneStub = sandbox.stub(User, 'findOne');
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
   describe('Signup', () => {
     it('should GET /signup', (done) => {
       request(app)
         .get('/signup')
         .expect(200)
         .end(done);
+    });
+
+    it('should redirect to /profile on successful POST /signup', (done) => {
+      findOneStub.resolves(false);
+      createStub.resolves({ new: 'user' });
+
+      const data = {
+        email: 'jose@email.com',
+        password: 'secretpassword',
+      };
+
+      request(app)
+        .post('/signup')
+        .send(data)
+        .expect(302)
+        .end((err, res) => {
+          expect(res.header.location).to.include('/profile');
+          done();
+        });
     });
   });
 });

--- a/test/app.js
+++ b/test/app.js
@@ -12,6 +12,17 @@ describe('GET /', () => {
   });
 });
 
+describe('Account', () => {
+  describe('Profile', () => {
+    it('should GET /profile', (done) => {
+      request(app)
+        .get('/profile')
+        .expect(200)
+        .end(done);
+    });
+  });
+});
+
 describe('GET /api', () => {
   it('should return 200 OK', (done) => {
     request(app)

--- a/test/app.js
+++ b/test/app.js
@@ -59,6 +59,24 @@ describe('Authentication', () => {
           done();
         });
     });
+
+    it('should redirect to /signup on failed POST /signup when user exists', (done) => {
+      findOneStub.resolves({ existing: 'user' });
+
+      const data = {
+        email: 'jose@email.com',
+        password: 'secretpassword',
+      };
+
+      request(app)
+        .post('/signup')
+        .send(data)
+        .expect(302)
+        .end((err, res) => {
+          expect(res.header.location).to.include('/signup');
+          done();
+        });
+    });
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,6 +2228,17 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
+passport-strategy@1.x.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
+
+passport@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/passport/-/passport-0.4.0.tgz#c5095691347bd5ad3b5e180238c3914d16f05811"
+  dependencies:
+    passport-strategy "1.x.x"
+    pause "0.0.1"
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -2271,6 +2282,10 @@ pause-stream@0.0.11:
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   dependencies:
     through "~2.3"
+
+pause@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
 
 pend@~1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,28 @@
 # yarn lockfile v1
 
 
+"@sinonjs/commons@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
+  dependencies:
+    "@sinonjs/samsam" "2.1.0"
+
+"@sinonjs/samsam@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  dependencies:
+    array-from "^2.1.1"
+
+"@sinonjs/samsam@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.2.tgz#16947fce5f57258d01f1688fdc32723093c55d3f"
+
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-7.0.4.tgz#bfd5b0d0d1ba13e351dff65b6e52783b816826c8"
@@ -119,6 +141,10 @@ arr-union@^3.1.0:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -717,7 +743,7 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -1655,6 +1681,10 @@ jstransformer@1.0.0:
     is-promise "^2.0.0"
     promise "^7.0.1"
 
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
+
 kew@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
@@ -1721,9 +1751,21 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash@^4.17.0, lodash@^4.17.1, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
 
 long@^4.0.0:
   version "4.0.0"
@@ -2009,6 +2051,16 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
+nise@^1.4.5:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.6.tgz#76cc3915925056ae6c405dd8ad5d12bde570c19f"
+  dependencies:
+    "@sinonjs/formatio" "3.0.0"
+    just-extend "^3.0.0"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
+
 node-pre-gyp@0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
@@ -2272,6 +2324,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -2847,6 +2905,20 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sinon@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.0.0.tgz#99f2e5198d90a01ccbcebd4dc181a24827cb90dd"
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.2"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^3.0.0"
+    nise "^1.4.5"
+    supports-color "^5.5.0"
+    type-detect "^4.0.8"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -3061,6 +3133,12 @@ supports-color@5.4.0, supports-color@^5.2.0, supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  dependencies:
+    has-flag "^3.0.0"
+
 tar@^4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
@@ -3091,6 +3169,10 @@ terraformer@~1.0.5:
   resolved "https://registry.yarnpkg.com/terraformer/-/terraformer-1.0.9.tgz#77851fef4a49c90b345dc53cf26809fdf29dcda6"
   optionalDependencies:
     "@types/geojson" "^1.0.0"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 throttleit@^1.0.0:
   version "1.0.0"
@@ -3168,7 +3250,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-type-detect@^4.0.0:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,6 +2228,12 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
+passport-local@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/passport-local/-/passport-local-1.0.0.tgz#1fe63268c92e75606626437e3b906662c15ba6ee"
+  dependencies:
+    passport-strategy "1.x.x"
+
 passport-strategy@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"


### PR DESCRIPTION
### What
- Add signup with passport:
  - Add GET /signup view with form
  - Add POST /signup route to handle form submission
  - Add passport local-signup strategy
  - Add GET /profile view for successful signup
  - Initialize and configure passport in app

### New libs
- [passport](http://www.passportjs.org/) for handling signup and login
- [passport-local](https://www.npmjs.com/package/passport-local) for creating a local login strategy
- [sinon](https://sinonjs.org/releases/v7.0.0/) for mocking db requests in unit tests

### How to test
- Confirm new unit tests are passing
- Try signing up with an email that is already used for a user record, and confirm you get a 302 redirect to the /signup route
- Try signing up with a valid email and password, and confirm you get a 302 redirect to the /profile route, and a new record appears in your users table

### Some references
- [Notes on passport docs](https://www.raymondcamden.com/2016/06/23/some-quick-tips-for-passport)
- Two tutorials that I went back and forth between for examples. Neither covers all the gaps and neither is perfectly consistent with the official passport docs. 
  - [Tutorial 1 - more official](https://scotch.io/tutorials/easy-node-authentication-setup-and-local)
  - [Tutorial 2 - less official but uses MySQL and sequelize](https://scotch.io/@GM456742/building-a-nodejs-web-app-using-passportjs-for-authentication)
- [Some notes on using Sinon.js in unit tests](https://semaphoreci.com/community/tutorials/best-practices-for-spies-stubs-and-mocks-in-sinon-js)
