### PR TITLE
Issue 47 add local login with passport, #47

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -50,4 +50,35 @@ passport.use('local-signup', new LocalStrategy(
   }
 ));
 
+passport.use('local-login', new LocalStrategy(
+  {
+    // Field names must match request body
+    usernameField : 'email',
+    passwordField : 'password',
+  },
+  function(email, password, done) {
+    db.User.findOne({
+      where: {
+        email: email
+      }
+    }).then(function(dbUser) {
+      // If there's no user found with the given email
+      if (!dbUser) {
+        return done(null, false, {
+          message: "User not found.",
+        });
+      }
+      // If the given password doesn't match
+      else if (!dbUser.validPassword(password)) {
+        return done(null, false, {
+          message: "Email and password do not match.",
+        });
+      }
+      // If user exists and password matches, return user
+      return done(null, dbUser);
+    });
+  }
+));
+
+
 module.exports = passport;

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -42,6 +42,8 @@ module.exports = (app) => {
     });
   });
 
+  // Log in form
+
   // --- Handle data --- //
 
   // Receive Signup Submission
@@ -52,6 +54,8 @@ module.exports = (app) => {
       failureRedirect: '/signup',
     })
   );
+
+  // Receive Login Submission
 
   // ------- END AUTHENTICATION ROUTES ------- //
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -61,6 +61,12 @@ module.exports = (app) => {
   );
 
   // Receive Login Submission
+  app.post('/login', configuredPassport.authenticate(
+    'local-login',
+    {
+      successRedirect : '/profile',
+      failureRedirect : '/login',
+    }));
 
   // ------- END AUTHENTICATION ROUTES ------- //
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -43,6 +43,11 @@ module.exports = (app) => {
   });
 
   // Log in form
+  app.get('/login', function(req, res) {
+    res.render('login', {
+      title: 'JP Login',
+    });
+  });
 
   // --- Handle data --- //
 

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -5,4 +5,7 @@ html
     div
       h1= message
     hr
-    a(href='/signup') Local Sign Up
+    div
+      a(href='/signup') Local Sign Up
+    div
+      a(href='/login') Local Log In

--- a/src/views/login.pug
+++ b/src/views/login.pug
@@ -12,4 +12,7 @@ html
           input.form-control(type='password', name='password')
         button.btn.btn-warning.btn-lg(type='submit') Login
       hr
-      a(href='/') Home
+      div
+        a(href='/') Home
+      div
+        a(href='/signup') Sign up for a new account

--- a/src/views/login.pug
+++ b/src/views/login.pug
@@ -1,0 +1,15 @@
+html
+  head
+    title= title
+  body
+    div
+      form(action='/login', method='post')
+        .form-group
+          label Email
+          input.form-control(type='text', name='email')
+        .form-group
+          label Password
+          input.form-control(type='password', name='password')
+        button.btn.btn-warning.btn-lg(type='submit') Login
+      hr
+      a(href='/') Home

--- a/src/views/signup.pug
+++ b/src/views/signup.pug
@@ -12,4 +12,8 @@ html
           input.form-control(type='password', name='password')
         button(type='submit') Signup
       hr
-      a(href='/') Home
+      div
+        a(href='/') Home
+      div
+        | Already have an account?&nbsp
+        a(href='/login') Log in

--- a/test/app.js
+++ b/test/app.js
@@ -140,6 +140,24 @@ describe('Authentication', () => {
           done();
         });
     });
+
+    it('should redirect to /login on failed POST /login when the password is invalid', (done) => {
+      const validPasswordStub = sandbox.stub().returns(false);
+      findOneStub.resolves({ validPassword: validPasswordStub });
+       const data = {
+        email: 'jose@email.com',
+        password: 'secretpassword',
+      };
+       request(app)
+        .post('/login')
+        .send(data)
+        .expect(302)
+        .end((err, res) => {
+          expect(res.header.location).to.include('/login');
+          expect(validPasswordStub.called).to.be.true;
+          done();
+        });
+    });
   });
 });
 

--- a/test/app.js
+++ b/test/app.js
@@ -97,6 +97,15 @@ describe('Authentication', () => {
         });
     });
   });
+
+  describe('Login', () => {
+    it('should GET /login', (done) => {
+      request(app)
+        .get('/login')
+        .expect(200)
+        .end(done);
+    });
+  });
 });
 
 describe('Account', () => {

--- a/test/app.js
+++ b/test/app.js
@@ -124,6 +124,22 @@ describe('Authentication', () => {
           done();
         });
     });
+
+     it('should redirect to /login on failed POST /login when the email doesn\'t match a user', (done) => {
+      findOneStub.resolves(false);
+       const data = {
+        email: 'jose@email.com',
+        password: 'secretpassword',
+      };
+       request(app)
+        .post('/login')
+        .send(data)
+        .expect(302)
+        .end((err, res) => {
+          expect(res.header.location).to.include('/login');
+          done();
+        });
+    });
   });
 });
 

--- a/test/app.js
+++ b/test/app.js
@@ -1,3 +1,4 @@
+/*jshint expr: true*/
 'use strict';
 
 const request = require('supertest');
@@ -104,6 +105,24 @@ describe('Authentication', () => {
         .get('/login')
         .expect(200)
         .end(done);
+    });
+
+    it('should redirect to /profile on successful POST /login', (done) => {
+      const validPasswordStub = sandbox.stub().returns(true);
+      findOneStub.resolves({ validPassword: validPasswordStub });
+       const data = {
+        email: 'jose@email.com',
+        password: 'secretpassword',
+      };
+       request(app)
+        .post('/login')
+        .send(data)
+        .expect(302)
+        .end((err, res) => {
+          expect(res.header.location).to.include('/profile');
+          expect(validPasswordStub.called).to.be.true;
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
### What
- Add local login routes with password authentication
  - Add GET /login view with form
  - Add POST /login route to handle form submission
  - Add passport local-login strategy
- Similar to https://github.com/swoloszynski/journey-planner/pull/51 (see references in that PR)

### How to test
- Confirm new unit tests are passing
- Try logging in with an email that doesn't have a user record, and confirm you get a 302 redirect to the /login route
- Try logging in with an email that has a user record and the incorrect password, and confirm you get a 302 redirect to the /login route
- Try logging in with a valid email and password combination and confirm you get a 302 redirect to the /profile route

