### PR TITLE
Issue 57 protect access to login page, closes #57

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -3,11 +3,19 @@ const LocalStrategy = require('passport-local').Strategy;
 const db            = require('../src/models/');
 
 passport.serializeUser(function(user, cb) {
-  cb(null, user);
+  // Sets req.session.passport.user
+  const sessionUser = {
+    id: user.id,
+    username: user.username,
+    email: user.email,
+    name: user.name,
+  };
+  cb(null, sessionUser);
 });
 
-passport.deserializeUser(function(obj, cb) {
-  cb(null, obj);
+passport.deserializeUser(function(sessionUser, cb) {
+  // Gets sessionUser from req.session.passport.user
+  cb(null, sessionUser);
 });
 
 passport.use('local-signup', new LocalStrategy(

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "npm run lint && NODE_ENV=test mocha --exit test",
+    "test": "npm run lint && NODE_ENV=test mocha --exit test/*",
     "start": "nodemon app.js",
     "lint": "jshint app.js src test"
   },

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  required: (req, res, next) => {
+    if (req.user) {
+      return next();
+    }
+    res.redirect('/login');
+  },
+};

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -21,7 +21,8 @@ module.exports = (app) => {
     res.setHeader('Content-Type', 'text/html');
     res.render('index', {
       title: 'Journey Planner',
-      message:'Hello World!'
+      message:'Hello World!',
+      user: req.user,
     });
   });
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -2,6 +2,7 @@
 
 const usersController = require('../controllers').users;
 const configuredPassport = require('../../../config/passport');
+const auth = require('../middleware/auth');
 
 module.exports = (app) => {
   app.set('views', './src/views');
@@ -29,9 +30,10 @@ module.exports = (app) => {
   // --- Views --- //
 
   // Profile view (authenticated users only)
-  app.get('/profile', function(req, res) {
+  app.get('/profile', auth.required, function(req, res) {
     res.render('profile', {
       title: 'JP Profile',
+      user: req.user,
     });
   });
 

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -5,7 +5,12 @@ html
     div
       h1= message
     hr
-    div
-      a(href='/signup') Local Sign Up
-    div
-      a(href='/login') Local Log In
+    if user && user.name
+      div
+        p Welcome #{user.name}
+        a(href='/profile') Profile
+    else
+      div
+        a(href='/signup') Local Sign Up
+      div
+        a(href='/login') Local Log In

--- a/src/views/profile.pug
+++ b/src/views/profile.pug
@@ -4,8 +4,8 @@ html
   body
     | Profile page
     if user && user.name
-      p= user.name
+      p #{user.name}'s Profile Page
+      br
+      a(href='/logout') Log Out
     hr
     a(href='/') Home
-    br
-    a(href='/logout') Log out

--- a/src/views/profile.pug
+++ b/src/views/profile.pug
@@ -3,5 +3,7 @@ html
     title= title
   body
     | Profile page
+    if user && user.name
+      p= user.name
     hr
     a(href='/') Home

--- a/test/app.js
+++ b/test/app.js
@@ -163,11 +163,14 @@ describe('Authentication', () => {
 
 describe('Account', () => {
   describe('Profile', () => {
-    it('should GET /profile', (done) => {
+    it('should GET /profile and redirect when not logged in', (done) => {
       request(app)
         .get('/profile')
-        .expect(200)
-        .end(done);
+        .expect(302)
+        .end((err, res) => {
+          expect(res.header.location).to.include('/login');
+          done();
+        });
     });
   });
 });

--- a/test/controllers/account.js
+++ b/test/controllers/account.js
@@ -10,7 +10,7 @@ const accountController = require('../../src/server/controllers').account;
 
 describe('Account Controller', () => {
   describe('render', () => {
-    it('should render profile template', () => {
+    it('should render profile template if no user', () => {
       const req = httpMocks.createRequest();
       const res = httpMocks.createResponse();
 
@@ -23,6 +23,27 @@ describe('Account Controller', () => {
 
       const templateData = res._getRenderData();
       expect(templateData.title).to.eql('JP Profile');
+      expect(templateData.user).to.be.undefined;
+    });
+
+    it('should render profile template and pass user data if exists', () => {
+      const req = httpMocks.createRequest({
+        user: {
+          pretend: 'user',
+        },
+      });
+      const res = httpMocks.createResponse();
+
+      accountController.render(req, res);
+
+      expect(res.statusCode).to.eql(200);
+
+      const templateName = res._getRenderView();
+      expect(templateName).to.eql('profile');
+
+      const templateData = res._getRenderData();
+      expect(templateData.title).to.eql('JP Profile');
+      expect(templateData.user).to.eql({ pretend: 'user' });
     });
   });
 });

--- a/test/controllers/home.js
+++ b/test/controllers/home.js
@@ -10,7 +10,7 @@ const homeController = require('../../src/server/controllers').home;
 
 describe('Home Controller', () => {
   describe('render', () => {
-    it('should render index template', () => {
+    it('should render index template if no user', () => {
       const req = httpMocks.createRequest();
       const res = httpMocks.createResponse();
 
@@ -24,6 +24,27 @@ describe('Home Controller', () => {
       const templateData = res._getRenderData();
       expect(templateData.title).to.eql('Journey Planner');
       expect(templateData.message).to.eql('Hello World!');
+      expect(templateData.user).to.be.undefined;
+    });
+
+    it('should render index template and pass user data if exists', () => {
+      const req = httpMocks.createRequest({
+        user: {
+          pretend: 'user',
+        },
+      });
+      const res = httpMocks.createResponse();
+
+      homeController.render(req, res);
+
+      expect(res.statusCode).to.eql(200);
+
+      const templateName = res._getRenderView();
+      expect(templateName).to.eql('index');
+
+      const templateData = res._getRenderData();
+      expect(templateData.title).to.eql('Journey Planner');
+      expect(templateData.user).to.eql({ pretend: 'user' });
     });
   });
 });

--- a/test/middleware/auth.js
+++ b/test/middleware/auth.js
@@ -1,0 +1,44 @@
+/*jshint expr: true*/
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+
+const auth = require('../../src/server/middleware/auth');
+
+describe('Auth middleware', () => {
+  describe('required', () => {
+    afterEach( () => {
+      sinon.restore();
+    });
+
+    it('should call next() when user exists', () => {
+      const fakeReq = {
+        user: true,
+      };
+      const fakeRes = {
+        redirect: sinon.fake(),
+      };
+      const fakeNext = sinon.fake();
+
+      auth.required(fakeReq, fakeRes, fakeNext);
+
+      expect(fakeRes.redirect.called).to.be.false;
+      expect(fakeNext.called).to.be.true;
+    });
+
+    it('should redirect to login if user does not exist', () => {
+      const fakeReq = {};
+      const fakeRes = {
+        redirect: sinon.fake(),
+      };
+      const fakeNext = sinon.fake();
+
+      auth.required(fakeReq, fakeRes, fakeNext);
+
+      expect(fakeRes.redirect.called).to.be.true;
+      expect(fakeNext.called).to.be.false;
+    });
+  });
+});

--- a/test/views/home.js
+++ b/test/views/home.js
@@ -1,0 +1,50 @@
+/*jshint expr: true*/
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const pug = require('pug');
+
+const path = require('path');
+const app = require('../../app.js');
+
+describe('Views - Home', () => {
+  const file = path.join(app.get('views'), 'index.pug');
+  const compiledFunction = pug.compileFile(file);
+
+  describe('user data exists', () => {
+    const userData = {
+      username: 'amazinggrace123',
+      name: 'Grace',
+    };
+    it('should display username', () => {
+      const renderedTemplate = compiledFunction({
+        message: 'Journey Planner!',
+        user: userData,
+      });
+      expect(renderedTemplate).to.contain('Welcome Grace');
+    });
+
+    it('should not display login or signup links', () => {
+      const renderedTemplate = compiledFunction({
+        message: 'Journey Planner!',
+        user: userData,
+      });
+      expect(renderedTemplate).to.not.contain('Log In');
+      expect(renderedTemplate).to.not.contain('Sign Up');
+    });
+  });
+
+  describe('user data does not exist', () => {
+    it('should not display login or signup links', () => {
+      const renderedTemplate = compiledFunction({
+        message: 'Journey Planner!',
+      });
+      expect(renderedTemplate).to.not.contain('Welcome');
+      expect(renderedTemplate).to.contain('Log In');
+      expect(renderedTemplate).to.contain('Sign Up');
+    });
+  });
+
+});

--- a/test/views/profile.js
+++ b/test/views/profile.js
@@ -1,0 +1,48 @@
+/*jshint expr: true*/
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const pug = require('pug');
+
+const path = require('path');
+const app = require('../../app.js');
+
+describe('Views - Profile', () => {
+  const file = path.join(app.get('views'), 'profile.pug');
+  const compiledFunction = pug.compileFile(file);
+
+  describe('user data exists', () => {
+    const userData = {
+      username: 'amazinggrace123',
+      name: 'Grace',
+    };
+    it('should display username', () => {
+      const renderedTemplate = compiledFunction({
+        message: 'Journey Planner!',
+        user: userData,
+      });
+      expect(renderedTemplate).to.contain('Grace\'s Profile Page');
+    });
+
+    it('should display logout links', () => {
+      const renderedTemplate = compiledFunction({
+        message: 'Journey Planner!',
+        user: userData,
+      });
+      expect(renderedTemplate).to.contain('Log Out');
+    });
+  });
+
+  describe('user data does not exist', () => {
+    it('should not display login or signup links', () => {
+      const renderedTemplate = compiledFunction({
+        message: 'Journey Planner!',
+      });
+      expect(renderedTemplate).to.not.contain('\'s Profile Page');
+      expect(renderedTemplate).to.not.contain('Log Out');
+    });
+  });
+
+});


### PR DESCRIPTION
### What
- Adds auth.required middleware to redirect the user to /login if they are not logged in, otherwise proceed
- Adds middleware unit tests 🙌 
- Require authentication to access /profile
- Pass user object to /profile and / templates in order to change display if the user is logged in
- Update controller unit tests to check user data
- Add view tests to confirm that homepage and profile templates are rendered correctly if user data is/isn't present 🙌 

### How to Test
- Visit /profile and see that you're redirected to /login
- View / and see the login and sign up links
- Log in
  - Confirm the username displays on the profile page
  - Confirm the username displays on the home page /
  - Confirm that you can access the profile page after logging in
- Check unit tests

### Note
- Haven't been able to get integration tests working for testing authenticated requests, but I've covered the cases by creating smaller unit tests (controller/view tests). Happy to add integration tests in the future if we can get them working! 