### PR TITLE
Issue 67 add log out, closes #67

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "npm run lint && NODE_ENV=test mocha --exit test",
+    "test": "npm run lint && NODE_ENV=test mocha --exit test/*",
     "start": "nodemon app.js",
     "lint": "jshint app.js src test"
   },

--- a/src/server/controllers/auth.js
+++ b/src/server/controllers/auth.js
@@ -1,0 +1,7 @@
+'use strict';
+ module.exports = {
+  logout(req, res) {
+    req.logout();
+    res.redirect('/');
+  },
+};

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const users = require('./users');
+const auth = require('./auth');
 
 module.exports = {
+  auth,
   users,
 };

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const usersController = require('../controllers').users;
+const authController = require('../controllers').auth;
+
 const configuredPassport = require('../../../config/passport');
 
 module.exports = (app) => {
@@ -56,6 +58,9 @@ module.exports = (app) => {
   });
 
   // --- Handle data --- //
+
+  // Logout
+  app.get('/logout', authController.logout);
 
   // Receive Signup Submission
   app.post('/signup', configuredPassport.authenticate(

--- a/src/views/profile.pug
+++ b/src/views/profile.pug
@@ -5,3 +5,5 @@ html
     | Profile page
     hr
     a(href='/') Home
+    br
+    a(href='/logout') Log out

--- a/test/controllers/auth.js
+++ b/test/controllers/auth.js
@@ -1,0 +1,27 @@
+/*jshint expr: true*/
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const authController = require('../../src/server/controllers').auth;
+
+describe('Auth Controller', () => {
+  describe('logout', () => {
+    afterEach( () => {
+      sandbox.restore();
+    });
+
+    it('should call req.logout()', () => {
+      const fakeReq = {
+        logout: sandbox.fake(),
+      };
+      const fakeRes = {
+        redirect: sinon.fake(),
+      };
+      authController.logout(fakeReq, fakeRes);
+      expect(fakeReq.logout.called).to.be.true;
+      expect(fakeRes.redirect.called).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
### What
- Adds a GET /logout route that invokes passport's logout function
- Adds a logout link to /profile and / page when the user is logged in
- Adds controller test for auth controller 🙌 

### How to test
- Log in, then log out by clicking link on home page, profile page, or manually going to /logout